### PR TITLE
Replace time with std::time, threadpool with rayon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,4 @@ A little testing library.
 """
 
 [dependencies]
-time = "*"
-
-[dependencies.threadpool]
-version = "*"
-features = ["scoped-pool"]
+rayon = "0.4.0"

--- a/src/reporters.rs
+++ b/src/reporters.rs
@@ -1,8 +1,7 @@
-extern crate time;
-
 use types::{TestResult,TestTimings,TestStats};
 
 use std::io;
+use std::time::Instant;
 
 pub trait Reporter {
     fn start(&mut self);
@@ -68,16 +67,14 @@ impl Reporter for ProgressReporter {
 }
 
 pub struct StatisticsReporter {
-    start_time: u64,
-    end_time: u64,
+    start_time: Instant,
     results: Vec<TestResult>
 }
 
 impl StatisticsReporter {
     pub fn new() -> StatisticsReporter {
         StatisticsReporter {
-            start_time: 0,
-            end_time: 0,
+            start_time: Instant::now(),
             results: Vec::new()
         }
     }
@@ -86,16 +83,15 @@ impl StatisticsReporter {
 impl Reporter for StatisticsReporter {
     fn start(&mut self) {
         println!("# Running.\n");
-        self.start_time = time::precise_time_ns();
+        self.start_time = Instant::now();
     }
     fn record(&mut self, result: &TestResult) {
         self.results.push(result.clone());
     }
     fn report(&mut self) {
-        self.end_time = time::precise_time_ns();
+        let elapsed = self.start_time.elapsed();
 
-        let time_ms = self.end_time.wrapping_sub(self.start_time) as i64 / 1000000;
-        let time_s = time_ms as f64 / 1000f64;
+        let time_s = elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1000_000_000f64;
         let timings = TestTimings {
             time_s: time_s,
             runs_per_s: self.results.len() as f64 / time_s

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,7 +27,7 @@ pub struct TestTimings {
 
 impl fmt::Display for TestTimings {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Finished in {}s, {} runs/s.", self.time_s, self.runs_per_s)
+        write!(f, "Finished in {:3}s, {} runs/s.", self.time_s, self.runs_per_s)
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,6 @@
 extern crate littletest;
 
-use littletest::{Runnable, TestResult, TestOptions, TestRunner};
+use littletest::{Runnable, TestResult, TestRunner};
 
 struct TestCase {
     result: TestResult
@@ -29,8 +29,6 @@ fn it_works() {
         .map(|result| Box::new(TestCase::new(result)) as Box<Runnable + Sync>)
         .collect::<Vec<_>>();
 
-    let runner = TestRunner::new(TestOptions {
-        parallelism: Some(4)
-    });
+    let runner = TestRunner::new(true);
     runner.run(&runnables);
 }


### PR DESCRIPTION
Removes TestOptions in favor of a plain bool to turn off parallelism as rayon handles load balance
